### PR TITLE
Add instructions to run tutorial in Google Colaboratory

### DIFF
--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -11,12 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial shows how to synthesize diffusion MRI data using [Disimpy](https://disimpy.readthedocs.io/en/latest/). Two options to follow the tutorial are:\n",
-    "\n",
-    "1. [Install](https://disimpy.readthedocs.io/en/latest/installation.html) Disimpy and execute the code in each cell in the order that they are presented here.\n",
-    "2. [Run this notebook interactively in your browser](https://colab.research.google.com/github/kerkelae/disimpy/blob/master/docs/source/tutorial.ipynb) using [Google Colab](https://colab.research.google.com/). This allows following along the tutorial even if you do not have a Nvidia CUDA-enabled GPU (see [hardware requirements](https://disimpy.readthedocs.io/en/latest/installation.html#hardware-requirements)). Two extra steps are needed in this case, in the following order:\n",
-    "    1. When you have opened the Google Colab notebook, select **Runtime** > **Change runtime type** > **Hardware Type: GPU**.\n",
-    "    2. Uncomment the line containing `!pip install git+https://github.com/kerkelae/disimpy.git` in the first code cell.\n"
+    "This tutorial shows how to synthesize diffusion MRI data using [Disimpy](https://disimpy.readthedocs.io/en/latest/). To follow along, [install](https://disimpy.readthedocs.io/en/latest/installation.html) Disimpy and execute the code in each cell in the order that they are presented here. Alternatively, you can [run this notebook interactively in your browser](https://colab.research.google.com/github/kerkelae/disimpy/blob/master/docs/source/tutorial.ipynb) (even if you do not have a Nvidia CUDA-enabled GPU). In this case, when you have opened the Google Colab notebook, select **Runtime** > **Change runtime type** > **Hardware Type: GPU** and then uncomment the line containing `!pip install git+https://github.com/kerkelae/disimpy.git` in the first code cell.\n"
    ]
   },
   {
@@ -25,9 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# -------------------------------------------------------------------------------------\n",
     "# If running this on Google Colab uncomment the following line before running this cell\n",
-    "# -------------------------------------------------------------------------------------\n",
     "# !pip install git+https://github.com/kerkelae/disimpy.git\n",
     "\n",
     "# Import packages and modules used in this tutorial\n",

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -11,12 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial shows how to synthesize diffusion MRI data using disimpy. Two options to follow the tutorial are:\n",
+    "This tutorial shows how to synthesize diffusion MRI data using [Disimpy](https://disimpy.readthedocs.io/en/latest/). Two options to follow the tutorial are:\n",
     "\n",
-    "A. [Install](https://disimpy.readthedocs.io/en/latest/installation.html) Disimpy and execute the code in each cell in the order that they are presented here.\n",
-    "\n",
-    "B. [Run this notebook interactively in your browser](https://colab.research.google.com/github/kerkelae/disimpy/blob/master/docs/source/tutorial.ipynb) using [Google Colab](https://colab.research.google.com/). This allows following along the tutorial even if you do not have a Nvidia CUDA-enabled GPU (see [hardware requirements](https://disimpy.readthedocs.io/en/latest/installation.html#hardware-requirements)). Two extra steps are needed in this case, in the following order:\n",
-    "    1. When you have opened the Google Colab notebook, select **Runtime** > **Change runtime type** > **Hardware Type**: GPU.\n",
+    "1. [Install](https://disimpy.readthedocs.io/en/latest/installation.html) Disimpy and execute the code in each cell in the order that they are presented here.\n",
+    "2. [Run this notebook interactively in your browser](https://colab.research.google.com/github/kerkelae/disimpy/blob/master/docs/source/tutorial.ipynb) using [Google Colab](https://colab.research.google.com/). This allows following along the tutorial even if you do not have a Nvidia CUDA-enabled GPU (see [hardware requirements](https://disimpy.readthedocs.io/en/latest/installation.html#hardware-requirements)). Two extra steps are needed in this case, in the following order:\n",
+    "    1. When you have opened the Google Colab notebook, select **Runtime** > **Change runtime type** > **Hardware Type: GPU**.\n",
     "    2. Uncomment the line containing `!pip install git+https://github.com/kerkelae/disimpy.git` in the first code cell.\n"
    ]
   },
@@ -566,7 +565,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -11,7 +11,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial shows how to synthesize diffusion MRI data using Disimpy. You can follow the tutorial by executing the code in each shell in the order that they are presented here."
+    "This tutorial shows how to synthesize diffusion MRI data using disimpy. Two options to follow the tutorial are:\n",
+    "\n",
+    "A. [Install](https://disimpy.readthedocs.io/en/latest/installation.html) Disimpy and execute the code in each cell in the order that they are presented here.\n",
+    "\n",
+    "B. [Run this notebook interactively in your browser](https://colab.research.google.com/github/kerkelae/disimpy/blob/master/docs/source/tutorial.ipynb) using [Google Colab](https://colab.research.google.com/). This allows following along the tutorial even if you do not have a Nvidia CUDA-enabled GPU (see [hardware requirements](https://disimpy.readthedocs.io/en/latest/installation.html#hardware-requirements)). Two extra steps are needed in this case, in the following order:\n",
+    "    1. When you have opened the Google Colab notebook, select **Runtime** > **Change runtime type** > **Hardware Type**: GPU.\n",
+    "    2. Uncomment the line containing `!pip install git+https://github.com/kerkelae/disimpy.git` in the first code cell.\n"
    ]
   },
   {
@@ -20,8 +26,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import packages and modules used in this tutorial\n",
+    "# -------------------------------------------------------------------------------------\n",
+    "# If running this on Google Colab uncomment the following line before running this cell\n",
+    "# -------------------------------------------------------------------------------------\n",
+    "# !pip install git+https://github.com/kerkelae/disimpy.git\n",
     "\n",
+    "# Import packages and modules used in this tutorial\n",
     "import os\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",


### PR DESCRIPTION
This is to enable users without an Nvidia GPU to run the tutorial in their browser, using Google Colaboratory (which provides free access to GPUs).